### PR TITLE
fixed dates: "January 21-24, 2024" -> "January 14-17, 2024"

### DIFF
--- a/cfp.html
+++ b/cfp.html
@@ -59,7 +59,7 @@
                 <a href="index.html">CIDR 2024</a>
             </h1>
 
-            <p>January 21-24, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
+            <p>January 14-17, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
         </div>
 
         <div id="leftside">
@@ -126,7 +126,7 @@
                     <strong>October 5, 2023</strong>: author notification for all contributions
                     
                 <dt>
-                    <strong>January 21-24, 2024</strong>: conference
+                    <strong>January 14-17, 2024</strong>: conference
 
                 <!-- <dt>
 
@@ -141,7 +141,7 @@ contributions
 	all contributions
 
 	<dt>
-<strong>January 21-24, 2024</strong>: conference
+<strong>January 14-17, 2024</strong>: conference
 <dl> -->
 
                 </br>
@@ -180,7 +180,7 @@ Submissions must be formatted using the ACM SIG style (see the <a href="https://
 
 Camera-ready papers need to follow the formatting instructions above. Additionally, they need to include the following copyright notice at the bottom left of the first page. This <a href="cidr-2024.cls">LaTeX style file</a> and this <a href="pubform-CIDR2024.docx">Word template file</a> include the copyright notice. We recommend that you use it, which will display the following information:
 <p>
-<i>This paper is published under the Creative Commons Attribution 4.0 International (CC-BY 4.0) license. Authors reserve their rights to disseminate the work on their personal and corporate Web sites with the appropriate attribution, provided that you attribute the original work to the authors and CIDR 2024. 14th Annual Conference on Innovative Data Systems Research (CIDR '24). January 21-24, 2024, Chaminade, USA.</i>
+<i>This paper is published under the Creative Commons Attribution 4.0 International (CC-BY 4.0) license. Authors reserve their rights to disseminate the work on their personal and corporate Web sites with the appropriate attribution, provided that you attribute the original work to the authors and CIDR 2024. 14th Annual Conference on Innovative Data Systems Research (CIDR '24). January 14-17, 2024, Chaminade, USA.</i>
 
 <h3>Diversity and Inclusion</h3>
 

--- a/cidr-2024.cls
+++ b/cidr-2024.cls
@@ -1268,7 +1268,7 @@
   \global\@ACM@journal@bibstripfalse
 }
 \if@ACM@journal\else
-\acmConference[CIDR'24]{14th Annual Conference on Innovative Data Systems Research}{January 21-24, 2024}{Chaminade, USA}
+\acmConference[CIDR'24]{14th Annual Conference on Innovative Data Systems Research}{January 14-17, 2024}{Chaminade, USA}
 
 \fi
 \def\acmBooktitle#1{\gdef\@acmBooktitle{#1}}

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
 
         <div id="header">
             <h1><a href="index.html">CIDR 2024</a></h1>
-            <p>January 21-24, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
+            <p>January 14-17, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
         </div>
 
         <!--

--- a/keynotespeakers.html
+++ b/keynotespeakers.html
@@ -17,7 +17,7 @@
 
         <div id="header">
             <h1><a href="index.html">CIDR 2024</a></h1>
-            <p>January 21-24, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
+            <p>January 14-17, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
         </div>
 
         <div id="leftside">

--- a/officers.html
+++ b/officers.html
@@ -16,7 +16,7 @@
 
         <div id="header">
             <h1><a href="index.html">CIDR 2024</a></h1>
-            <p>January 21-24, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
+            <p>January 14-17, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
         </div>
 
         <div id="leftside">

--- a/org.html
+++ b/org.html
@@ -16,7 +16,7 @@
 
         <div id="header">
             <h1><a href="index.html">CIDR 2024</a></h1>
-            <p>January 21-24, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
+            <p>January 14-17, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
         </div>
 
         <div id="leftside">

--- a/program.html
+++ b/program.html
@@ -25,7 +25,7 @@
 
         <div id="header">
             <h1><a href="index.html">CIDR 2024</a></h1>
-            <p>January 21-24, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
+            <p>January 14-17, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
         </div>
 
         <div id="leftside">

--- a/registration.html
+++ b/registration.html
@@ -128,7 +128,7 @@
                 <a href="index.html">CIDR 2024</a>
             </h1>
             <p>
-            <p>January 21-24, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
+            <p>January 14-17, 2024 <span style="padding-left:30px"> Chaminade, USA</span></p>
             </p>
         </div>
 
@@ -175,9 +175,8 @@
 			<h3>Venue</h3>
 
 <p>
-CIDR 2024 will be held from Sunday, January 08, 2024, to Wednesday, January
-11, 2024, in the Mövenpick Hotel Amsterdam City Centre, Piet Heinkade 11,
-1019 BR Amsterdam, Netherlands.
+CIDR 2024 will be held from Sunday, January 14, 2024, to Wednesday, January 17, 2024,
+at Chaminade Resort & Spa, a mountaintop hotel in Santa Cruz, California
 
 <a name="Zoom Registration"></a>
 <h3>Zoom Registration (free)</h3>


### PR DESCRIPTION
Chaminade is not available for the week after the third Sunday in Jan 2024; hence, we have to stick with the original pattern and dates starting on the second Sunday in Jan 2024.